### PR TITLE
Remove dead code in publisher and call rollbar on kinesis errors

### DIFF
--- a/__tests__/stopcovid/dialog/command_stream/test_publish.py
+++ b/__tests__/stopcovid/dialog/command_stream/test_publish.py
@@ -8,21 +8,30 @@ from stopcovid.dialog.command_stream.publish import CommandPublisher
 class TestCommandPublisher(unittest.TestCase):
     def setUp(self) -> None:
         logging.disable(logging.CRITICAL)
-        kinesis_client = MagicMock()
+        self.kinesis_client = MagicMock()
         self.put_records_mock = MagicMock()
-        kinesis_client.put_records = self.put_records_mock
+        self.kinesis_client.put_records = self.put_records_mock
         get_kinesis_client_patch = patch(
             "stopcovid.dialog.command_stream.publish.CommandPublisher._get_kinesis_client",
-            return_value=kinesis_client,
+            return_value=self.kinesis_client,
         )
         get_kinesis_client_patch.start()
         self.addCleanup(get_kinesis_client_patch.stop)
         self.command_publisher = CommandPublisher()
 
-    def publish_process_sms(self):
+    def test_publish_process_sms(self):
         self.command_publisher.publish_process_sms_command("123456789", "lol", {"foo": "bar"})
         self.put_records_mock.assert_called_once()
         self.assertEqual(1, len(self.put_records_mock.call_args[1]["Records"]))
         self.assertEqual(
-            "123456789", self.put_records_mock.call_args[1]["Records"][0]["PartitionKey"]
+            "123456789", self.put_records_mock.call_args[1]["Records"][0]["PartitionKey"],
         )
+
+    @patch("stopcovid.dialog.command_stream.publish.rollbar")
+    def test_put_records_error(self, rollbar_mock):
+        kinesis_response = {"FailedRecordCount": 3, "foo": "bar"}
+        put_records_mock = MagicMock(return_value=kinesis_response)
+        self.kinesis_client.put_records = put_records_mock
+        self.command_publisher.publish_process_sms_command("123456789", "lol", {"foo": "bar"})
+        put_records_mock.assert_called_once()
+        rollbar_mock.report_exc_info.assert_called_once_with(extra_data=kinesis_response)

--- a/stopcovid/dialog/aws_lambdas/publish_dialog_event_batches.py
+++ b/stopcovid/dialog/aws_lambdas/publish_dialog_event_batches.py
@@ -37,4 +37,6 @@ def _publish_event_batches_to_kinesis(event_batches: List[DialogEventBatch]):
         {"PartitionKey": event_batch.phone_number, "Data": json.dumps(event_batch.to_dict())}
         for event_batch in event_batches
     ]
-    kinesis.put_records(StreamName=stream_name, Records=records)
+    response = kinesis.put_records(StreamName=stream_name, Records=records)
+    if response.get("FailedRecordCount"):
+        rollbar.report_exc_info(extra_data=response)

--- a/stopcovid/dialog/command_stream/publish.py
+++ b/stopcovid/dialog/command_stream/publish.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 from typing import Dict, Any, List, Tuple
-
+import rollbar
 import boto3
 
 
@@ -38,4 +38,6 @@ class CommandPublisher:
             {"Data": json.dumps(data), "PartitionKey": phone_number}
             for phone_number, data in commands
         ]
-        kinesis.put_records(StreamName=f"command-stream-{self.stage}", Records=records)
+        response = kinesis.put_records(StreamName=f"command-stream-{self.stage}", Records=records)
+        if response.get("FailedRecordCount"):
+            rollbar.report_exc_info(extra_data=response)

--- a/stopcovid/dialog/command_stream/publish.py
+++ b/stopcovid/dialog/command_stream/publish.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import os
-from typing import Dict, Any, Optional, List, Tuple
+from typing import Dict, Any, List, Tuple
 
 import boto3
 
@@ -32,23 +32,10 @@ class CommandPublisher:
     def _get_kinesis_client():
         return boto3.client("kinesis")
 
-    @staticmethod
-    def _get_last_seq(phone_number) -> Optional[str]:
-        return None
-
-    @staticmethod
-    def _try_record_seq(phone_number, seq):
-        pass
-
     def _publish_commands(self, commands: List[Tuple[str, Dict[str, Any]]]):
         kinesis = self._get_kinesis_client()
-        records = []
-        for phone_number, data in commands:
-            last_seq = self._get_last_seq(phone_number)
-            record = {"Data": json.dumps(data), "PartitionKey": phone_number}
-            if last_seq:
-                record["SequenceNumberForOrdering"] = last_seq
-            records.append(record)
-        response = kinesis.put_records(StreamName=f"command-stream-{self.stage}", Records=records)
-        for i, result in enumerate(response["Records"]):
-            self._try_record_seq(records[i]["PartitionKey"], result["SequenceNumber"])
+        records = [
+            {"Data": json.dumps(data), "PartitionKey": phone_number}
+            for phone_number, data in commands
+        ]
+        kinesis.put_records(StreamName=f"command-stream-{self.stage}", Records=records)


### PR DESCRIPTION
I might be missing something, but this code looks like it just doesnt do anything. The rollbar we got was related to an error from kinesis, which we have no observability into. This PR cleans up the dead code and calls rollbar when we get an error from kinesis