### PR TITLE
fix requirements deployment issue

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -8,6 +8,8 @@ custom:
   logForwarding:
       destinationARN: ${ssm:/stopcovid/${self:provider.stage}/logForwardingDestinationArn}
   pythonRequirements:
+    usePoetry: false
+    usePipenv: false
     slim: true
     slimPatterns:
       - __tests__/**


### PR DESCRIPTION
cool so I think the `pyproject.toml` file is causing serverless to think we're using peotry for dependency management for whatever reason. This seems to fix it.