### PR TITLE
HACK: put resulting account info on all events

### DIFF
--- a/__tests__/stopcovid/dialog/test_engine.py
+++ b/__tests__/stopcovid/dialog/test_engine.py
@@ -20,7 +20,7 @@ from stopcovid.dialog.models.events import (
     FailedPrompt,
     DrillCompleted,
 )
-from stopcovid.dialog.models.state import DialogState, PromptState
+from stopcovid.dialog.models.state import DialogState, PromptState, AccountInfo
 
 from stopcovid.dialog.registration import CodeValidationPayload
 from stopcovid.drills.drills import Drill, Prompt, PromptMessage
@@ -125,6 +125,13 @@ class TestProcessCommand(unittest.TestCase):
         self._assert_event_types(batch, DialogEventType.USER_VALIDATED)
         self.assertEqual(
             validation_payload, batch.events[0].code_validation_payload  # type: ignore
+        )
+        # and account info is set on the event and user profile
+        self.assertEqual(
+            batch.events[0].user_profile.account_info,
+            AccountInfo(
+                employer_id=1, unit_id=1, employer_name="employer_name", unit_name="unit_name"
+            ),
         )
 
     def test_revalidate_demo_user(self):

--- a/stopcovid/dialog/engine.py
+++ b/stopcovid/dialog/engine.py
@@ -71,6 +71,9 @@ def process_command(command: Command, seq: str, repo: DialogRepository = None):
         # side effects on the events that we're persisting. The user_profile on the event
         # should reflect the user_profile *before* the event is applied to the dialog_state.
         deepcopy(event).apply_to(dialog_state)
+    end_account_info = dialog_state.user_profile.account_info
+    for event in events:
+        event.user_profile.account_info = end_account_info
     dialog_state.seq = seq
     repo.persist_dialog_state(
         DialogEventBatch(events=events, phone_number=command.phone_number, seq=seq), dialog_state,


### PR DESCRIPTION
There's a bug in marshmallow that only shallow copies events. That means that account info was getting updated on all events without us realizing it, and we built some logic on top of that assumption. This restores the shallowcopy behavior for now.