### PR TITLE
put user profile updates onto events

### DIFF
--- a/__tests__/stopcovid/dialog/models/test_events.py
+++ b/__tests__/stopcovid/dialog/models/test_events.py
@@ -172,6 +172,7 @@ class TestCompletedPrompt(unittest.TestCase):
         event.apply_to(dialog_state)
         self.assertEqual(profile, dialog_state.user_profile)
         self.assertIsNone(dialog_state.current_prompt_state)
+        self.assertIsNone(event.user_profile_updates)
 
     def test_completed_and_stored(self):
         profile = UserProfile(validated=True)
@@ -192,6 +193,7 @@ class TestCompletedPrompt(unittest.TestCase):
         event.apply_to(dialog_state)
         self.assertEqual(UserProfile(validated=True, self_rating_1="7"), dialog_state.user_profile)
         self.assertIsNone(dialog_state.current_prompt_state)
+        self.assertEqual(event.user_profile_updates, {"self_rating_1": "7"})
 
 
 class TestFailedPrompt(unittest.TestCase):

--- a/stopcovid/dialog/models/events.py
+++ b/stopcovid/dialog/models/events.py
@@ -45,7 +45,7 @@ class DialogEvent(pydantic.BaseModel):
     created_time: datetime = pydantic.Field(default_factory=lambda: datetime.now(UTC))
     event_id: uuid.UUID = pydantic.Field(default_factory=uuid.uuid4)
     schema_version: int = SCHEMA_VERSION
-    user_profile_updates: Optional[Dict[str, str]]
+    user_profile_updates: Optional[Dict[str, str]] = None
 
     @abstractmethod
     def apply_to(self, dialog_state: DialogState):

--- a/stopcovid/dialog/models/events.py
+++ b/stopcovid/dialog/models/events.py
@@ -45,6 +45,7 @@ class DialogEvent(pydantic.BaseModel):
     created_time: datetime = pydantic.Field(default_factory=lambda: datetime.now(UTC))
     event_id: uuid.UUID = pydantic.Field(default_factory=uuid.uuid4)
     schema_version: int = SCHEMA_VERSION
+    user_profile_updates: Optional[Dict[str, str]]
 
     @abstractmethod
     def apply_to(self, dialog_state: DialogState):
@@ -102,6 +103,7 @@ class CompletedPrompt(DialogEvent):
     def apply_to(self, dialog_state: DialogState):
         dialog_state.current_prompt_state = None
         if self.prompt.response_user_profile_key:
+            self.user_profile_updates = {self.prompt.response_user_profile_key: self.response}
             setattr(
                 dialog_state.user_profile, self.prompt.response_user_profile_key, self.response,
             )

--- a/stopcovid/drills/drills.py
+++ b/stopcovid/drills/drills.py
@@ -22,9 +22,6 @@ class Prompt(pydantic.BaseModel):
             return True
         return is_correct_response(answer, self.correct_response)
 
-    def stores_answer(self) -> bool:
-        return self.response_user_profile_key is not None
-
 
 class Drill(pydantic.BaseModel):
     slug: str


### PR DESCRIPTION
This is motivated by enabling ESL module selection in scadmin. We need to be able to subscribe users to drills based on what "level" they select. We could add this to the user profile as it is today, but we've discussed internally that denormalizing user profile data between dynamo and scadmin is clunky.

This could be a proof of concept for removing the user profile from dynamo state. I think it would look something like:
1) all events have an optional "user_profile_updates" dict. All user profile updates would go in there
2) scadmin would update the user profile content with anything on the event
3) scadmin could optionally execute additional logic for certain keywords (like "esl_level")

Another way to do this would be to add a UserProfileUpdated event type. I think we could make that work, but we'd be introducing complexity around user validated and opted out events. What order would the two come in? Should we be guaranteeing atomicity within an event?

To help paint the picture, here's what we'd do in the UserValidated event:
`self.user_profile_updates = {"validated": True, "is_demo":  self.code_validation_payload.is_demo}`