### PR TITLE
Fix user profile updates dict

### DIFF
--- a/__tests__/stopcovid/dialog/models/test_events.py
+++ b/__tests__/stopcovid/dialog/models/test_events.py
@@ -193,7 +193,6 @@ class TestCompletedPrompt(unittest.TestCase):
         event.apply_to(dialog_state)
         self.assertEqual(UserProfile(validated=True, self_rating_1="7"), dialog_state.user_profile)
         self.assertIsNone(dialog_state.current_prompt_state)
-        self.assertEqual(event.user_profile_updates, {"self_rating_1": "7"})
 
 
 class TestFailedPrompt(unittest.TestCase):

--- a/__tests__/stopcovid/dialog/test_engine.py
+++ b/__tests__/stopcovid/dialog/test_engine.py
@@ -325,6 +325,7 @@ class TestProcessCommand(unittest.TestCase):
         self._assert_event_types(
             batch, DialogEventType.COMPLETED_PROMPT, DialogEventType.DRILL_COMPLETED,
         )
+        self.assertEqual(batch.events[0].user_profile_updates, {"language": "en"})
 
     @patch("stopcovid.drills.drills.Prompt.should_advance_with_answer", return_value=False)
     def test_conclude_with_too_many_wrong_answers(self, *args):
@@ -346,6 +347,7 @@ class TestProcessCommand(unittest.TestCase):
         self.assertTrue(failed_event.abandoned)
         self.assertEqual(failed_event.response, "completely wrong answer")
         self.assertEqual(failed_event.drill_instance_id, self.drill_instance_id)
+        self.assertEqual(batch.events[0].user_profile_updates, None)
 
         advanced_event: AdvancedToNextPrompt = batch.events[1]  # type: ignore
         self.assertEqual(self.drill.prompts[4], advanced_event.prompt)

--- a/stopcovid/dialog/engine.py
+++ b/stopcovid/dialog/engine.py
@@ -213,11 +213,15 @@ class ProcessSMSMessage(Command):
             return None
         events: List[DialogEvent] = []
         if prompt.should_advance_with_answer(self.content_lower):
+            user_profile_updates = None
+            if prompt.response_user_profile_key:
+                user_profile_updates = {prompt.response_user_profile_key: self.content}
             events.append(
                 CompletedPrompt(
                     prompt=prompt,
                     drill_instance_id=dialog_state.drill_instance_id,
                     response=self.content,
+                    user_profile_updates=user_profile_updates,
                     **base_args,
                 )
             )

--- a/stopcovid/dialog/models/events.py
+++ b/stopcovid/dialog/models/events.py
@@ -103,7 +103,6 @@ class CompletedPrompt(DialogEvent):
     def apply_to(self, dialog_state: DialogState):
         dialog_state.current_prompt_state = None
         if self.prompt.response_user_profile_key:
-            self.user_profile_updates = {self.prompt.response_user_profile_key: self.response}
             setattr(
                 dialog_state.user_profile, self.prompt.response_user_profile_key, self.response,
             )


### PR DESCRIPTION
The dict needs to be in the constructor, _not_ in the apply_to method. We deepcopy the events, so any mutations made in apply_to are lost. Setting this in the constructor is better anyway, don't know why I didn't think of this first.