### PR TITLE
Thin out user profile

### DIFF
--- a/__tests__/stopcovid/dialog/models/test_events.py
+++ b/__tests__/stopcovid/dialog/models/test_events.py
@@ -174,26 +174,6 @@ class TestCompletedPrompt(unittest.TestCase):
         self.assertIsNone(dialog_state.current_prompt_state)
         self.assertIsNone(event.user_profile_updates)
 
-    def test_completed_and_stored(self):
-        profile = UserProfile(validated=True)
-        event = CompletedPrompt(
-            phone_number="123456789",
-            user_profile=profile,
-            prompt=DRILL.prompts[1],
-            drill_instance_id=uuid.uuid4(),
-            response="7",
-        )
-        dialog_state = DialogState(
-            phone_number="123456789",
-            seq="0",
-            user_profile=profile,
-            current_drill=DRILL,
-            current_prompt_state=PromptState(slug=DRILL.prompts[0].slug, start_time=NOW),
-        )
-        event.apply_to(dialog_state)
-        self.assertEqual(UserProfile(validated=True, self_rating_1="7"), dialog_state.user_profile)
-        self.assertIsNone(dialog_state.current_prompt_state)
-
 
 class TestFailedPrompt(unittest.TestCase):
     def test_failed_and_not_abandoned(self):

--- a/__tests__/stopcovid/dialog/models/test_state.py
+++ b/__tests__/stopcovid/dialog/models/test_state.py
@@ -18,3 +18,10 @@ class TestUserProfileSerialization(unittest.TestCase):
         serialized = profile.json()
         deserialized = UserProfile(**json.loads(serialized))
         self.assertIsNone(deserialized.language)
+
+    def test_user_profile_ignores_additional_fields(self):
+        profile = UserProfile(validated=True, language="en", foo="bar", joel="embiid")
+        self.assertEqual("en", profile.language)
+        serialized = profile.json()
+        deserialized = UserProfile(**json.loads(serialized))
+        self.assertEqual("en", deserialized.language)

--- a/__tests__/stopcovid/drill_progress/test_state.py
+++ b/__tests__/stopcovid/drill_progress/test_state.py
@@ -18,7 +18,6 @@ class TestUserProfile(unittest.TestCase):
         expected = {
             "validated": True,
             "is_demo": True,
-            "name": "Devin Booker",
             "language": "en",
             "account_info": {
                 "employer_id": 1,
@@ -29,4 +28,4 @@ class TestUserProfile(unittest.TestCase):
             "opted_out": False,
         }
 
-        self.assertDictContainsSubset(expected, profile.dict())
+        self.assertEqual(expected, profile.dict())

--- a/stopcovid/dialog/models/events.py
+++ b/stopcovid/dialog/models/events.py
@@ -109,7 +109,7 @@ class CompletedPrompt(DialogEvent):
                 )
             except AttributeError:
                 # the dialog engine represenatation of the user profile does not accept this field.
-                # the data attr and response will be persisted on the DialogEvent.user_profile_updates dict
+                # the key response will be persisted on the DialogEvent.user_profile_updates dict
                 pass
 
 

--- a/stopcovid/dialog/models/events.py
+++ b/stopcovid/dialog/models/events.py
@@ -103,9 +103,14 @@ class CompletedPrompt(DialogEvent):
     def apply_to(self, dialog_state: DialogState):
         dialog_state.current_prompt_state = None
         if self.prompt.response_user_profile_key:
-            setattr(
-                dialog_state.user_profile, self.prompt.response_user_profile_key, self.response,
-            )
+            try:
+                setattr(
+                    dialog_state.user_profile, self.prompt.response_user_profile_key, self.response,
+                )
+            except AttributeError:
+                # the dialog engine represenatation of the user profile does not accept this field.
+                # the data attr and response will be persisted on the DialogEvent.user_profile_updates dict
+                pass
 
 
 class FailedPrompt(DialogEvent):

--- a/stopcovid/dialog/models/state.py
+++ b/stopcovid/dialog/models/state.py
@@ -13,24 +13,8 @@ class UserProfile(pydantic.BaseModel):
     validated: bool
     opted_out: bool = False
     is_demo: bool = False
-    name: Optional[str] = None
     language: Optional[str] = None
     account_info: Optional[AccountInfo] = None
-    self_rating_1: Optional[str] = None
-    self_rating_2: Optional[str] = None
-    self_rating_3: Optional[str] = None
-    self_rating_4: Optional[str] = None
-    self_rating_5: Optional[str] = None
-    self_rating_6: Optional[str] = None
-    self_rating_7: Optional[str] = None
-    self_rating_8: Optional[str] = None
-    job: Optional[str] = None
-    schedule_days: Optional[str] = None
-    schedule_time: Optional[str] = None
-    esl_level: Optional[str] = None
-
-    def __str__(self):
-        return f"lang={self.language}, validated={self.validated}, " f"name={self.name}"
 
     @pydantic.validator("language", pre=True, always=True)
     def set_language(cls, value):


### PR DESCRIPTION
This is a step towards normalizing user profile data. Currently the user profile gets updated in the dialog engine, persisted in dynamo, and attached to each event. Scadmin then looks for user profile diffs on events to find updates.

I previously merged a pr #60 which puts user_profile_updates on the event. The naming is kind of confusing here, but I'm not too concerned about it